### PR TITLE
Removed logout and added token expiration tests

### DIFF
--- a/backend-ROR/app/controllers/session_controller.rb
+++ b/backend-ROR/app/controllers/session_controller.rb
@@ -19,6 +19,4 @@ class SessionController < ApplicationController
       head :unauthorized
     end
   end
-  def destroy
-  end
 end

--- a/backend-ROR/config/routes.rb
+++ b/backend-ROR/config/routes.rb
@@ -7,8 +7,7 @@ Rails.application.routes.draw do
   # get 'user/create'
   # get 'user/destroy'
 
-  resources :user, only: [:create, :destroy] do 
-    
+  resources :user, only: [:create, :destroy] do
     resources :blog do
       put '/viewcount', to: "blog#update_viewcount"
     end
@@ -16,7 +15,6 @@ Rails.application.routes.draw do
 
   get '/blog', to: 'blog#indexall'
   post '/login', to: 'session#create'
-  delete '/logout', to: 'session#destroy'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/backend-ROR/db/seeds.rb
+++ b/backend-ROR/db/seeds.rb
@@ -74,10 +74,10 @@ Blog.create!(title: 'Best gym in the D.C. area?',
              content: 'Sign up for a membership today...',
              user_id: user2.id,
              topics_id: Topic.find_by(name: 'Data-Driven Fitness').id,
-             view_count: 2)
+             view_count: 3)
 
 Blog.create!(title: 'Reasons why you shouldn\'t say you\'re good at math?',
              content: 'If a plane and a car both leave Orlando heading towards Washington D.C...',
              user_id: user2.id,
              topics_id: Topic.find_by(name: 'Programming Languages').id,
-             view_count: 2)
+             view_count: 4)

--- a/backend-ROR/lib/json_web_token.rb
+++ b/backend-ROR/lib/json_web_token.rb
@@ -2,8 +2,8 @@
 
 class JsonWebToken
   def self.encode(payload)
-    exp = 24.hour.from_now.to_i
-    JWT.encode(payload, Rails.application.secret_key_base, 'HS256', exp: exp)
+    payload[:exp] = 24.hour.from_now.to_i
+    JWT.encode(payload, Rails.application.secret_key_base, 'HS256')
   end
 
   def self.decode(token)

--- a/backend-ROR/test/controllers/session_controller_test.rb
+++ b/backend-ROR/test/controllers/session_controller_test.rb
@@ -11,6 +11,8 @@ class SessionControllerTest < ActionDispatch::IntegrationTest
     assert JSON.parse(response.body)['first_name'] == @user1.first_name
     assert JSON.parse(response.body)['last_name'] == @user1.last_name
     assert JsonWebToken.decode(JSON.parse(response.body)['token'])['user_id'] == @user1.id
+    get '/blog', headers: { 'Authorization' => JSON.parse(response.body)['token'] }, as: :json
+    assert_response :ok
   end
   test 'login fails when username is bad' do
     post '/login', params: { email: 'nope, not a valid email', password: 'password1' }, as: :json
@@ -22,6 +24,16 @@ class SessionControllerTest < ActionDispatch::IntegrationTest
   end
   test 'login fails when json is missing' do
     post '/login'
+    assert_response :unauthorized
+  end
+  test 'authorization fails when token is missing' do
+    get '/blog'
+    assert_response :unauthorized
+  end
+  test 'authorization fails when token is expired' do
+    token = JWT.encode({ user_id: @user1.id, exp: 1.seconds.from_now.to_i }, Rails.application.secret_key_base, 'HS256')
+    sleep(2)
+    get '/blog', headers: { 'Authorization' => token }, as: :json
     assert_response :unauthorized
   end
 end


### PR DESCRIPTION
There is no need for a logout function because there is no simple way to destroy the token. Instead, the frontend should simply discard the token in order to logout.

I also wrote tests for expired tokens, which I found out was not actually working. I fixed it and it now works.